### PR TITLE
replyMsgの変更 Firestoreからテーマに応じたニュースを返す

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,13 +1,3 @@
-
-// // Create and Deploy Your First Cloud Functions
-// // https://firebase.google.com/docs/functions/write-firebase-functions
-//
-/*
-exports.helloWorld = functions.https.onRequest((request, response) => {
-  functions.logger.info("Hello logs!", {structuredData: true});
-  response.send("Hello from Firebase!");
-});
-*/
 "use strict";
 
 const functions = require("firebase-functions");
@@ -18,6 +8,25 @@ const express = require("express");
 const app = express();
 const line = require("@line/bot-sdk");
 require("dotenv").config();
+
+const {
+  replyCaseYes,
+  replyCaseYesStamp,
+  replyCaseNoStamp,
+  replyCaseNoSelectbox,
+  replyCaseSomehow,
+  replyCaseSomohowSelectbox,
+  replyCaseBusy,
+  replyCaseBusyStamp,
+  replyCaseSkip,
+  replyCaseSkipStamp,
+  replyAdviceHealth,
+  replyAdviceMeal,
+  replyAdviceExercise,
+  replyAdviceProblems,
+  replyAdviceWorry,
+  replyUnexpected
+} = require("./variables")
 
 const config = {
   channelSecret: process.env.CHANNEL_SECRET,
@@ -45,66 +54,111 @@ async function handleEvent(event) {
   if (event.type !== "message" || event.message.type !== "text") {
     return Promise.resolve(null);
   }
-  const documentArray = []
+  const documentArray = [];
   const getRandomElement = (array) => {
-    let min = 0
-    let max = array.length-1
-    let randomIndex = Math.floor(Math.random() * (max - min + 1) + min)
-    return array[randomIndex]
-  }
+    const min = 0;
+    const max = array.length-1;
+    const randomIndex = Math.floor(Math.random() * (max - min + 1) + min);
+    return array[randomIndex];
+  };
 
-  try {
-    const db = admin.firestore()
-    // const doc = await db.collection("news").doc("K6O5Jnqk4g1EFien29Ru").get()
-    await db.collection("news")
-        .get().then(function(querySnapshot) {
-          querySnapshot.forEach(function(doc) {
-            documentArray.push({
-              category: doc.data().category,
-              sourceUrl: doc.data().sourceUrl,
-              createdAt: doc.data().createdAt,
-            });
-          });
-        });
-    
-    const replyUrl = getRandomElement(documentArray).sourceUrl
-    return client.replyMessage(event.replyToken, {
-      type: "text",
-      text: replyUrl // 返信のテキストが入る箇所
-    });
-  } catch (e) {
-    console.error(e)
-  }
-}
-/*
-async function fetchNewsData() {
-  const news =[];
+  const textMessage = [];
+
+  const replyMessage = (messageFromUser) => {
+    const filteredArray = (arr, query) => {
+      return arr.filter(function (news) {
+              return news.category === query
+            })
+     }
+    switch (messageFromUser) {
+      case "はい":
+            return textMessage.push(replyCaseYesStamp, replyCaseYes);
+          case "いいえ":
+            return textMessage.push(replyCaseNoStamp, replyCaseNoSelectbox);
+          case "なんとなく・・・":
+            return textMessage.push(
+                replyCaseSomehow,
+                replyCaseSomohowSelectbox);
+          case "時間がなかった・・・":
+            return textMessage.push(
+                replyCaseBusyStamp,
+                replyCaseBusy);
+          case "今回は大丈夫！":
+            return textMessage.push(replyCaseSkipStamp, replyCaseSkip);
+          case "体調のこと":
+            const helthNewsUrl = getRandomElement(filteredArray(documentArray,"health")).sourceUrl;
+            const textMessageHealthUrl = {
+              type: "text",
+              text: helthNewsUrl
+            }
+            return textMessage.push(replyAdviceHealth, textMessageHealthUrl);
+          case "食事のこと":
+            const mealNewsUrl = getRandomElement(filteredArray(documentArray,"meal")).sourceUrl;
+            const textMessageMealUrl = {
+              type: "text",
+              text: mealNewsUrl
+            }
+            return textMessage.push(replyAdviceMeal, textMessageMealUrl );
+          case "運動のこと":
+            const exerciseNewsUrl = getRandomElement(filteredArray(documentArray,"exercise")).sourceUrl;
+            const textMessageExerciseUrl = {
+              type: "text",
+              text: exerciseNewsUrl
+            }
+            return textMessage.push(
+                replyAdviceExercise,
+                textMessageExerciseUrl);
+          case "困りごと":
+            const problemNewsUrl = getRandomElement(filteredArray(documentArray,"problem")).sourceUrl;
+            const textMessageProblemsUrl = {
+              type: "text",
+              text: problemNewsUrl
+            }
+            return textMessage.push(
+                replyAdviceProblems,
+                textMessageProblemsUrl);
+          case "心配事":
+            const worryNewsUrl = getRandomElement(filteredArray(documentArray,"worry")).sourceUrl;
+            const textMessageWorryUrl = {
+              type: "text",
+              text: worryNewsUrl
+            }
+            return textMessage.push(
+                replyAdviceWorry,
+                textMessageWorryUrl);
+          default:
+            return textMessage.push(replyUnexpected);
+    }
+  };
+
   try {
     const db = admin.firestore();
     await db.collection("news")
-        .get().then(function(querySnapshot) {
-          querySnapshot.forEach(function(doc) {
-            news.push({
-              category: doc.data().category,
-              sourceUrl: doc.data().sourceUrl,
-              createdAt: doc.data().createdAt,
-            });
-          });
-        });
+            .get().then(function(querySnapshot) {
+              querySnapshot.forEach(function(doc) {
+                documentArray.push({
+                  category: doc.data().category,
+                  sourceUrl: doc.data().sourceUrl,
+                  createdAt: doc.data().createdAt,
+                });
+              });
+            })
 
-    return news[0].sourceUrl;
+    replyMessage(event.message.text)
+    return client.replyMessage(event.replyToken,textMessage)
+
   } catch (e) {
     console.error(e);
-    response.status(500).send(e);
   }
-}*/
+}
+
 
 exports.app = functions.https.onRequest(app);
 
 // タイマーで実行されるプッシュメッセージの送信のfunction
 // scheduleの()内にcronコマンドで書いて、日時指定する。例 "30 11 * * 3"毎週水曜11:30
 // テスト 毎分 "* * * * *"
-/*exports.scheduledFunc = functions
+/* exports.scheduledFunc = functions
     .region("asia-northeast1")
     .pubsub.schedule("30 11 * * 3")
     .onRun(async () => {

--- a/functions/variables.js
+++ b/functions/variables.js
@@ -1,0 +1,258 @@
+// 返信用のメッセージ
+
+// 連絡取ってるか「はい」への応答
+exports.replyCaseYes = {
+  "type": "text",
+  "text": "その調子で頑張って！声を聞かせたり、元気な姿を見せるのは、あなたが思う以上に嬉しいものよ $",
+  "emojis": [
+    {
+      "index": 45,
+      "productId": "5ac1bfd5040ab15980c9b435",
+      "emojiId": "044",
+    },
+  ],
+};
+exports.replyCaseYesStamp =
+{
+  "type": "sticker",
+  "packageId": "8515",
+  "stickerId": "16581242",
+};
+
+// 連絡取ってるか「いいえ」への応答
+exports.replyCaseNoStamp =
+{
+  "type": "sticker",
+  "packageId": "1070",
+  "stickerId": "17866",
+};
+
+// 選択肢のflex message
+exports.replyCaseNoSelectbox = {
+  "type": "flex",
+  "altText": "this is a flex message",
+  "contents": {
+    "type": "bubble",
+    "body": {
+      "type": "box",
+      "layout": "vertical",
+      "contents": [
+        {
+          "type": "text",
+          "text": "理由は何かしら？",
+          "weight": "bold",
+          "size": "md",
+        },
+      ],
+    },
+    "footer": {
+      "type": "box",
+      "layout": "vertical",
+      "contents": [
+        {
+          "type": "button",
+          "action": {
+            "type": "message",
+            "label": "なんとなく・・・",
+            "text": "なんとなく・・・",
+          },
+        },
+        {
+          "type": "button",
+          "action": {
+            "type": "message",
+            "label": "時間がなかった・・・",
+            "text": "時間がなかった・・・",
+          },
+        },
+        {
+          "type": "button",
+          "action": {
+            "type": "message",
+            "label": "今回は大丈夫！",
+            "text": "今回は大丈夫！",
+          },
+        },
+      ],
+    },
+    "styles": {
+      "body": {
+        "backgroundColor": "#FDDDDE",
+      },
+    },
+  },
+};
+
+// 連絡取ってるか「なんとなく・・・」への応答
+exports.replyCaseSomehow = {
+  "type": "text",
+  "text": "「便りの無いのは良い便り」とは言っても、ちょっとしたコミュニケーションで気づくこともあるのよ $",
+  "emojis": [
+    {
+      "index": 47,
+      "productId": "5ac1bfd5040ab15980c9b435",
+      "emojiId": "043",
+    },
+  ],
+};
+// 理由を聞くflex message
+exports.replyCaseSomohowSelectbox = {
+  "type": "flex",
+  "altText": "this is a flex message",
+  "contents": {
+    "type": "bubble",
+    "body": {
+      "type": "box",
+      "layout": "vertical",
+      "contents": [
+        {
+          "type": "text",
+          "text": "よかったらご家族に聞いてみたら？",
+          "weight": "bold",
+          "size": "md",
+        },
+      ],
+    },
+    "footer": {
+      "type": "box",
+      "layout": "vertical",
+      "contents": [
+        {
+          "type": "button",
+          "action": {
+            "type": "message",
+            "label": "体調のこと",
+            "text": "体調のこと",
+          },
+        },
+        {
+          "type": "button",
+          "action": {
+            "type": "message",
+            "label": "食事のこと",
+            "text": "食事のこと",
+          },
+        },
+        {
+          "type": "button",
+          "action": {
+            "type": "message",
+            "label": "運動のこと",
+            "text": "運動のこと",
+          },
+        },
+        {
+          "type": "button",
+          "action": {
+            "type": "message",
+            "label": "困りごと",
+            "text": "困りごと",
+          },
+        },
+        {
+          "type": "button",
+          "action": {
+            "type": "message",
+            "label": "心配事",
+            "text": "心配事",
+          },
+        },
+      ],
+    },
+    "styles": {
+      "body": {
+        "backgroundColor": "#FDDDDE",
+      },
+    },
+  },
+};
+
+// 連絡取ってるか「時間がなかった・・・」への応答
+exports.replyCaseBusy = {
+  "type": "text",
+  "text": "だいたいみんなそうよね $\n最近うれしかったこととか、おいしかったご飯の写真とか送るだけでもいいと思うよ $",
+  "emojis": [
+    {
+      "index": 12,
+      "productId": "5ac1bfd5040ab15980c9b435",
+      "emojiId": "053",
+    },
+    {
+      "index": 53,
+      "productId": "5ac1bfd5040ab15980c9b435",
+      "emojiId": "074",
+    },
+  ],
+};
+
+exports.replyCaseBusyStamp =
+{
+  "type": "sticker",
+  "packageId": "6325",
+  "stickerId": "10979917",
+};
+// 連絡取ってるか「今回は大丈夫！」への応答
+exports.replyCaseSkip = {
+  "type": "text",
+  "text": "目標は月2回よ $",
+  "emojis": [
+    {
+      "index": 8,
+      "productId": "5ac21e6c040ab15980c9b444",
+      "emojiId": "011",
+    },
+  ],
+};
+
+exports.replyCaseSkipStamp =
+{
+  "type": "sticker",
+  "packageId": "6325",
+  "stickerId": "10979926",
+};
+
+// 「体調のこと」への応答
+exports.replyAdviceHealth = {
+  "type": "text",
+  "text":
+    "「最近、腰の調子はどう？」みたいに、さりげなーく聞くのがポイント\n突然改まって聞くと逆に不安にさせるの\n話題を送るから連絡するのよ",
+};
+
+// 「食事のこと」への応答
+exports.replyAdviceMeal = {
+  "type": "text",
+  "text": "食べる時間が不規則だったり、偏ったりしてるかも\n気にしてみてね\n話題を送るから連絡するのよ",
+};
+
+// 「運動のこと」への応答
+exports.replyAdviceExercise = {
+  "type": "text",
+  "text": "理想は「30分以上の運動を週2日以上」なの\n軽い散歩からススメてみて\n話題を送るから連絡するのよ",
+};
+
+
+// 「困りごと」への応答
+exports.replyAdviceProblems = {
+  "type": "text",
+  "text":
+    "重い物を運ぶとか、ちょっとしたことが難しくなるのよね\n帰省した時に手伝うとか、通販で贈るとかいいかも\n話題を送るから連絡するのよ",
+};
+
+// 「心配事」への応答
+exports.replyAdviceWorry = {
+  "type": "text",
+  "text": "詐欺とか事故多いわよね\nニュースを見た時とかに連絡をとると、ご家族もきっと安心するわよ\n話題を送るから連絡するのよ",
+};
+
+// 想定外への応答
+const replyUnexpected = {
+  "type": "text",
+  "text": "ごめん、それはよくわからないわ $",
+  "emojis": [
+    {
+      "index": 16,
+      "productId": "5ac1bfd5040ab15980c9b435",
+      "emojiId": "010",
+    },
+  ],
+};


### PR DESCRIPTION
BOTに送られたメッセージ（健康、食事、運動...）に合わせて、Firestoreからdocumentを取得して、お役立ち情報のURLを返すようにBOTの返答メッセージを改修した。